### PR TITLE
Improve webhook configuration

### DIFF
--- a/config/webhook/namespaceselector.yaml
+++ b/config/webhook/namespaceselector.yaml
@@ -4,6 +4,8 @@ metadata:
   name: mutating-webhook-configuration
 webhooks:
   - name: image-mapper.imagerelocation.pivotal.io
+    reinvocationPolicy: IfNeeded
+    matchPolicy: Equivalent
     namespaceSelector:
       matchExpressions:
         # avoid mutating pods in namespaces which are explicitly disabled


### PR DESCRIPTION
TODO: make the following conditional on the target kubernetes being at v1.15+.

Configure `reinvocationPolicy: IfNeeded` to ensure mutations by other webhooks
are processed (e.g. if a sidecar pod is injected, need to relocate the image).

Configure `matchPolicy: Equivalent` to ensure all versions of a pod spec are
processed.